### PR TITLE
修复README中的链接问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A concise APP about NBA News and Event with RxJava and EventBus。
 无广告、推送信息，不后台常驻，空间占用小。 
 所有数据均来自网络，并尽量注明信息来源，如有侵权，请告知！
 
-web后台部分在这（https://github.com/SilenceDut/nbaplus-server）
+web后台部分在这:[NBAPlus后台](https://github.com/SilenceDut/nbaplus-server) 
+
 如果对你有帮助给个star吧^_^
 
-贴个博客地址，虽然也没写过几篇(ˇˍˇ) （http://blog.csdn.net/ls5222325）
+贴个博客地址，虽然也没写过几篇(ˇˍˇ) [我的博客](http://blog.csdn.net/ls5222325)


### PR DESCRIPTION
两个链接都把括号放进去,变成了无效链接